### PR TITLE
Python11_wandb_fix

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1204,14 +1204,6 @@ six = ">=1.9.0,<2"
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
-[[package]]
-name = "wandb"
-version = "0.12.16"
-description = "A CLI and library for interacting with the Weights and Biases API."
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
 [package.dependencies]
 Click = ">=7.0,<8.0.0 || >8.0.0"
 docker-pycreds = ">=0.4.0"
@@ -1227,6 +1219,7 @@ sentry-sdk = ">=1.0.0"
 setproctitle = "*"
 shortuuid = ">=0.5.0"
 six = ">=1.13.0"
+wandb = ">=0.13.11"
 
 [package.extras]
 aws = ["boto3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,7 @@ PyYAML = "^6.0"
 psutil = "^5.9.0"
 setproctitle = "^1.2.2"
 opencv-python = "^4.5.5"
-wandb = "^0.12.11"
-ray = "^2.45.0"
+wandb = ">=0.13.11"
 
 ale-py = {version = "^0.7", optional = true}
 AutoROM = {version = "^0.4.2", optional = true, extras = ["accept-rom-license"]}


### PR DESCRIPTION
This PR relax the wandb version required by rl_games. I tested locally it work with IsaacLab 2.2.